### PR TITLE
Add optional base_ref input for compare commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,13 +3,8 @@ description: 'Get packages changes by folder'
 inputs:
   token:
     description: 'Github API token'
-  pull_requests_base_branch:
-    default: 'master'
-    description: 'Name of base branch'
-  merge_push_on:
-    default: 'sdx'
-    description: 'Name of branch will be created from base branch to merge PRs'
-
+  base_ref:
+    description: 'Optional branch for compare commits'
 
 runs:
   using: 'docker'

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const groupPackagesChanged = require('./group-package-changed')
 async function run () {
   try {
     const token = core.getInput('token', { required: true })
+    const base_ref = core.getInput('base_ref', { required: false })
     const octokit = github.getOctokit(token)
     const client = octokit.rest
 
@@ -28,6 +29,16 @@ async function run () {
         core.setFailed(
           `This action only supports pull requests and pushes, ${context.eventName} events are not supported. `,
         )
+    }
+
+    if (base_ref) {
+      const base_commit = await client.repos.getCommit({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: base_ref,
+      })
+
+      base = base_commit.data.sha
     }
 
     core.info(`Base commit: ${base}`)


### PR DESCRIPTION
Add an optional "base_ref" input for comparing commits. If set, "base_ref" will replace the default behavior.